### PR TITLE
hubot-slackのバージョンアップ及びherokuデプロイ設定の削除

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: node_js
 node_js:
   - "0.10"
 
-deploy:
-  provider: heroku
-  api_key: $HEROKU_API_KEY
-  app: $HEROKU_APP_NAME
+# Note: no longer use heroku
+# deploy:
+#   provider: heroku
+#   api_key: $HEROKU_API_KEY
+#   app: $HEROKU_APP_NAME
 
 #notifications:
 #  webhooks:

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bin/hubot -a slack

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.16.1",
     "hubot-shipit": "^0.2.0",
-    "hubot-slack": "^3.3.0",
+    "hubot-slack": "^4.4.0",
     "request": "^2.72.0"
   },
   "engines": {

--- a/scripts/nextbus.coffee
+++ b/scripts/nextbus.coffee
@@ -188,6 +188,9 @@ module.exports = (robot) ->
   robot.hear regex, (msg) ->
     call_yabus msg, msg.match[1]
 
-  HubotSlack = require 'hubot-slack'
-  robot.listeners.push new HubotSlack.SlackBotListener robot, regex, (msg) ->
-    call_yabus msg, msg.match[1]
+  # Below code may no longer need.
+  # ref.) https://github.com/slackapi/hubot-slack/issues/198#issuecomment-301954539
+  #
+  # HubotSlack = require 'hubot-slack'
+  # robot.listeners.push new HubotSlack.SlackBotListener robot, regex, (msg) ->
+  #   call_yabus msg, msg.match[1]


### PR DESCRIPTION
## hubot-slackのバージョンアップ

Slackとの接続が切れる問題について，hubot-slackのv4では修正が取り込まれているので，このレポジトリ内で使用しているhubot-slackのバージョンアップを行いました．
また，バージョンアップに伴いv4では必要ない記述をコメントアウトしました．
（参考: https://github.com/slackapi/hubot-slack/issues/198#issuecomment-301954539 ）


## herokuデプロイ設定の削除

herokuではなくゼミサーバで運用する方針に変わったため，heroku関連の設定を削除しました．